### PR TITLE
ng testコマンド実行のためにchromiumをインストール

### DIFF
--- a/angular-app/karma.conf.js
+++ b/angular-app/karma.conf.js
@@ -37,8 +37,19 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false,
-    restartOnFileChange: true
+    restartOnFileChange: true,
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chromium',
+        flags: [
+          '--no-sandbox',
+          '--headless',
+          '--disable-gpu',
+          '--remote-debugging-port=9222'
+        ],
+      }
+    }
   });
 };

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,5 +1,10 @@
 FROM node
 WORKDIR /projects
+
+RUN apt update -y
+# テスト用にchromeをインストール
+RUN apt install -y --no-install-recommends chromium
+
 RUN npm install -g @angular/cli
 EXPOSE 4200
 


### PR DESCRIPTION
下記のコマンドでテストを実行する

```
$ ng test --watch=false
```

参考：[Unable to run angular-cli karma-tests in docker with chrome-headless](https://stackoverflow.com/questions/57309284/unable-to-run-angular-cli-karma-tests-in-docker-with-chrome-headless)